### PR TITLE
Reorder global CSS imports

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -1,10 +1,10 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 /* Import Google Fonts */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Montserrat:wght@600&family=Roboto+Mono:wght@400&display=swap');
 @import "react-day-picker/dist/style.css"; /* Added react-day-picker CSS */
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 @layer base {
   :root {


### PR DESCRIPTION
## Summary
- move Google Fonts and react-day-picker imports ahead of Tailwind directives in globals.css to satisfy processing order

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68deaec46b78832bad6c4d290e0a542b